### PR TITLE
remove unused menu option

### DIFF
--- a/core_composer_app/menus.py
+++ b/core_composer_app/menus.py
@@ -3,7 +3,6 @@
 from django.urls import reverse
 from menu import Menu, MenuItem
 
-Menu.add_item("main", MenuItem("Composer", reverse("core_composer_index")))
 
 
 types_children = (


### PR DESCRIPTION
Removes unused menu option for creating templates from the MDCS banner