### PR TITLE
Revert "remove unused menu option"

### DIFF
--- a/core_composer_app/menus.py
+++ b/core_composer_app/menus.py
@@ -3,6 +3,7 @@
 from django.urls import reverse
 from menu import Menu, MenuItem
 
+Menu.add_item("main", MenuItem("Composer", reverse("core_composer_index")))
 
 
 types_children = (


### PR DESCRIPTION
This reverts commit b5ba19b21865ee82bd75a6519321a9c1bf891a75.

The removed button is now needed.